### PR TITLE
docs(cursor-rules): add repo-aligned Cursor rules (PRD, task breakdown, task progress)

### DIFF
--- a/.cursor/rules/prd-specification.mdc
+++ b/.cursor/rules/prd-specification.mdc
@@ -1,0 +1,69 @@
+---
+alwaysApply: false
+description: Specification and workflow for generating PRDs, aligned with this Go repo's processes (planning, quality gates, and next steps)
+---
+# Rule: Generating a Product Requirements Document (PRD)
+
+## Goal
+
+Create a clear, actionable PRD in Markdown for this Go-based LLM Proxy. The PRD should be understandable to a junior developer and align with the repository’s architecture and workflow described in `AGENTS.md` and `README.md`.
+
+## Process
+
+1.  **Receive Initial Prompt:** The user provides a short description of the feature or change.
+2.  **Ask Clarifying Questions:** Before writing the PRD, ask questions to understand the "what" and "why" (not the detailed "how"). Present options using letters/numbers for easy replies.
+3.  **Generate PRD:** Use the structure below, referencing repo docs where relevant.
+4.  **Save PRD:** Save as `prd-[feature-name].md` under `docs/tasks/`.
+
+## Clarifying Questions (Examples)
+
+Tailor questions to this project’s domains:
+
+* **Problem/Goal:** What user or operational problem does this solve in the proxy or admin/CLI flows?
+* **Target User:** Which persona is affected (CLI user, admin UI user, SRE/ops, downstream client)?
+* **Scope in LLM Proxy:** Which area(s) are impacted? Options: (A) Proxy routing/`internal/proxy` (B) Token lifecycle/`internal/token` (C) Management API/`internal/server` + `internal/admin` (D) Event bus/dispatcher/`internal/eventbus`+`internal/dispatcher` (E) Database models/`internal/database` (F) Logging/`internal/logging` (G) Obfuscation/security (H) Web admin templates under `web/templates`
+* **Functional Surface:** New endpoints? Changes to existing management routes? CLI flags? Config additions? Any template/UI changes?
+* **Data & Storage:** What data is created/read/updated/deleted? SQLite vs PostgreSQL considerations? Migrations needed?
+* **Observability:** Which events must be emitted? Should dispatcher integrations (file, Lunary, Helicone) be updated?
+* **Constraints:** Performance, rate limits, streaming, concurrency, or compatibility with `httputil.ReverseProxy`?
+* **Security:** Access control, token scopes, obfuscation, audit logging requirements?
+* **Acceptance Criteria:** What behavior and validations prove success?
+* **Non‑Goals:** What’s out of scope for this iteration?
+
+## PRD Structure
+
+1. **Introduction/Overview**: Describe the feature and problem it solves in the context of LLM Proxy.
+2. **Goals**: Measurable objectives (e.g., latency bound, correctness, admin UX improvement).
+3. **User Stories**: Narratives for CLI/admin/proxy users.
+4. **Functional Requirements**: Numbered list, explicit behavior for endpoints, CLI flags, token rules, events, logging.
+5. **Non‑Goals (Out of Scope)**: Keep scope tight.
+6. **Design Considerations (Optional)**: Reference `docs/architecture.md`, `docs/instrumentation.md`, `docs/api-configuration.md`, `PLAN.md` if applicable.
+7. **Technical Considerations (Optional)**: Go 1.23+, SQLite→PostgreSQL, reverse proxy behavior, concurrency model, config loading.
+8. **Success Metrics**: e.g., tests ≥ 90% coverage, `make test` green (with `-race`), `make lint` clean; performance or correctness metrics if relevant.
+9. **Open Questions**: Track items needing decisions.
+
+## Target Audience
+
+Assume a **junior Go developer**. Use explicit, unambiguous requirements and point to concrete repo files and packages where helpful.
+
+## Output
+
+* **Format:** Markdown (`.md`)
+* **Location:** `docs/tasks/`
+* **Filename:** `prd-[feature-name].md`
+
+## Final instructions
+
+1. Do NOT implement the feature in this document
+2. Ask clarifying questions first
+3. Refine the PRD after receiving answers
+
+## Follow-up & Cross-links
+
+- **Next step**: After PRD approval, create an implementation task list using [task-breakdown](mdc:.cursor/rules/task-breakdown.mdc).
+- **Project workflow**: Follow `AGENTS.md` for tests, coverage (≥ 90%), linting, and CI expectations.
+- **Key docs**: `README.md`, `PLAN.md`, `docs/architecture.md`, `docs/instrumentation.md`, `docs/cli-reference.md`, `docs/api-configuration.md`, `docs/security.md`.
+- **Quality gates**: Ensure `make test` (with `-race`) and `make lint` are green. For CI-style coverage locally:
+  - `go test -v -race -parallel=4 -coverprofile=coverage_ci.txt -covermode=atomic -coverpkg=./internal/... ./...`
+  - `go tool cover -func=coverage_ci.txt | tail -n 1`
+- **PRs**: Use GitHub as described in `AGENTS.md` (GitHub MCP recommended for PR metadata; conventional commits).

--- a/.cursor/rules/task-breakdown.mdc
+++ b/.cursor/rules/task-breakdown.mdc
@@ -1,0 +1,135 @@
+---
+alwaysApply: false
+description: Task list generation from a PRD for this Go repo (process, docs, changelog, and quality gates)
+---
+# Rule: Generating a Task List from a PRD
+
+## Goal
+
+Create a detailed, step-by-step implementation task list in Markdown based on a PRD, aligned with `AGENTS.md` and repository practices.
+
+## Output
+
+- **Format:** Markdown (`.md`)
+- **Location:** `docs/tasks/`
+- **Filename:** `tasks-[prd-file-name].md` (e.g., `tasks-prd-token-revocation.md`)
+
+## Process
+
+1. **Receive PRD Reference:** The user points to an existing PRD file in `docs/tasks/`.
+2. **Analyze PRD:** Read functional requirements, user stories, and constraints.
+3. **Phase 1 – Parent Tasks:** Generate 4–7 high-level tasks that cover all work. Present them without sub-tasks. Say: "I have generated the high-level tasks based on the PRD. Ready to generate the sub-tasks? Respond with 'Go' to proceed."
+4. **Wait for Confirmation:** Pause until the user says "Go".
+5. **Phase 2 – Sub-Tasks:** Break down each parent task into actionable sub-tasks.
+6. **Identify Relevant Files:** List files likely to be created/modified, including `_test.go` counterparts.
+7. **Include Documentation Tasks:** Always include updates to repo docs (see below).
+8. **Generate Final Output:** Combine sections in the prescribed format.
+9. **Save Task List:** Save in `docs/tasks/` as `tasks-[prd-file-name].md`.
+
+### Cross-links
+- **Project workflow**: `AGENTS.md` (tests, coverage ≥ 90%, linting, CI)
+- **PRs**: Use GitHub as in `AGENTS.md` (MCP tools recommended for PR metadata)
+- **Reference docs**: `README.md`, `PLAN.md`, `docs/architecture.md`, `docs/instrumentation.md`, `docs/cli-reference.md`, `docs/api-configuration.md`, `docs/security.md`
+
+## Output Format
+
+The generated task list must follow this structure:
+
+```markdown
+## Relevant Files
+
+- `internal/<package>/file.go` - Why this file/package is relevant.
+- `internal/<package>/file_test.go` - Unit tests for `file.go`.
+- `cmd/<entrypoint>/main.go` - CLI/server entrypoint changes if applicable.
+- `cmd/<entrypoint>/main_test.go` - Tests for the entrypoint behavior.
+- `docs/tasks/prd-<feature>.md` - The PRD that drives this work.
+- `docs/architecture.md` - Architecture updates if design changes.
+- `docs/instrumentation.md` - Event/dispatcher instrumentation updates if relevant.
+- `PLAN.md` - Project plan updates if scope or roadmap changes.
+
+### Notes
+
+- Go unit tests live alongside code as `*_test.go` in the same package.
+- Prefer targeted test runs during iteration.
+
+Use the following commands to run tests:
+
+#### Unit tests (fast)
+- `make test`
+- Equivalent (CI-style coverage aggregation):
+  - `go test -v -race -parallel=4 -coverprofile=coverage_ci.txt -covermode=atomic -coverpkg=./internal/... ./...`
+  - View summary: `go tool cover -func=coverage_ci.txt | tail -n 1`
+
+#### Targeted tests
+- By package: `go test ./internal/token -v -race`
+- Single test regex: `go test ./internal/token -v -race -run TestName`
+
+#### Integration tests
+- `go test -v -race -parallel=4 -tags=integration -timeout=5m -run Integration ./...`
+
+## Tasks
+
+- [ ] 1.0 Parent Task Title
+  - [ ] 1.1 [Sub-task description 1.1]
+  - [ ] 1.2 [Sub-task description 1.2]
+- [ ] 2.0 Parent Task Title
+  - [ ] 2.1 [Sub-task description 2.1]
+- [ ] 3.0 Parent Task Title (purely structural/configuration tasks may omit sub-tasks)
+- [ ] X.0 Update Documentation for [Feature Name]
+  - [ ] X.1 Update `docs/instrumentation.md` or relevant docs with [feature] details
+  - [ ] X.2 Update `docs/architecture.md`/`PLAN.md` with high-level design decisions
+  - [ ] X.3 Update `README.md` or `docs/cli-reference.md` if CLI/server usage changes
+  - [ ] X.4 Add/refresh `docs/tasks/prd-[feature].md` links and cross-references
+```
+
+## Interaction Model
+
+Pause after generating parent tasks. Proceed to sub-tasks only after the user replies "Go".
+
+## Commit and Push Strategy
+
+### Logical Commits
+- Group related changes into focused commits
+- Commit after completing a sub-task
+- Use conventional commits (`feat:`, `fix:`, `test:`, `docs:`, `refactor:`)
+
+### Commit Message Format
+Use multi-line commit messages with `-m` flags:
+```bash
+git commit -m "feat: primary change description" \
+           -m "- Detailed change 1" \
+           -m "- Detailed change 2" \
+           -m "- Reference to task/PRD context"
+```
+
+### Examples of Good Commit Groups
+1. **API/Type Changes**: `git add internal/token/token.go && git commit -m "feat(token): extend token with new property"`
+2. **Implementation Changes**: `git add internal/proxy/proxy.go && git commit -m "feat(proxy): implement new middleware"`
+3. **Test Changes**: `git add internal/token/token_test.go && git commit -m "test(token): add edge case tests"`
+4. **Documentation**: `git add docs/tasks/*.md && git commit -m "docs(tasks): update task completion status"`
+
+### Task Completion Workflow
+1. Complete sub-task → run targeted tests → commit
+2. After all sub-tasks of a parent are complete → run `make test` (and integration tests if touched) → push
+3. Never commit broken code
+
+### Testing Before Commits
+- Prefer targeted `go test` for affected packages/files
+- Ensure `make test` and `make lint` are green before pushing
+
+## Quality Gates Reminder
+- All tests pass (`make test`), including `-race`
+- Coverage ≥ 90% (use CI-style aggregation command above)
+- Linters pass (`make lint`)
+
+## Documentation Strategy
+
+Always include documentation tasks for:
+
+1. `docs/instrumentation.md` when events/dispatcher change
+2. `docs/architecture.md` for structural changes
+3. `README.md` and/or `docs/cli-reference.md` for user/CLI changes
+4. `PLAN.md` for roadmap/scope updates
+5. `docs/tasks/` PRD/task files for traceability
+
+Target audience is a **junior Go developer**.

--- a/.cursor/rules/task-progress.mdc
+++ b/.cursor/rules/task-progress.mdc
@@ -1,0 +1,66 @@
+---
+alwaysApply: false
+description: Task list execution and progress management for this Go repo (quality gates, docs, PR discipline)
+---
+# Task List Management
+
+Guidelines for managing task lists in Markdown to track progress on completing a PRD in this repository.
+
+## Task Implementation
+- **One sub-task at a time:** Do not start the next sub‑task until you ask the user for permission and they say "yes" or "y".
+- **Completion protocol:**
+  1. When you finish a **sub‑task**, immediately mark it as completed by changing `[ ]` to `[x]`.
+  2. If **all** subtasks under a parent are `[x]`, follow this sequence:
+    - **First**: Run only the relevant tests (avoid the entire suite):
+      - By package: `go test ./internal/<pkg> -v -race`
+      - Single test regex: `go test ./internal/<pkg> -v -race -run TestName`
+      - Entry points: `go test ./cmd/<entrypoint> -v -race`
+      - Integration (targeted): `go test -v -race -parallel=4 -tags=integration -timeout=5m -run Integration ./...`
+    - **Only if all tests pass**: Stage changes (`git add .`)
+    - **Clean up**: Remove any temporary files and temporary code before committing
+    - **Commit**: Use a descriptive commit message that:
+      - Uses conventional commit format (`feat:`, `fix:`, `refactor:`, `test:`, `docs:`)
+      - Summarizes what was accomplished in the parent task
+      - Lists key changes and additions
+      - References the task number and PRD context
+      - Formats the message as a single-line command using `-m` flags, e.g.:
+
+        ```
+        git commit -m "feat: add token revocation rules" -m "- Implements revoke path in manager" -m "- Adds unit tests for edge cases" -m "Related to tasks-prd-token.md"
+        ```
+  3. Once all subtasks are committed, mark the **parent task** as completed.
+- Stop after each sub‑task and wait for the user's go‑ahead.
+
+### Project-specific notes
+- Prefer running only the affected Go tests when iterating; run `make test` before pushing.
+- Always ensure linters pass: `make lint`. Format with `gofmt -w -s .` if needed.
+
+## Task List Maintenance
+
+1. **Update the task list as you work:**
+   - Mark tasks and subtasks as completed (`[x]`).
+   - Add new tasks if they emerge.
+
+2. **Maintain the "Relevant Files" section:**
+   - List every file created or modified.
+   - Give each file a one‑line purpose.
+
+## AI Instructions
+
+When working with task lists, the AI must:
+
+1. Update the task list file after each significant work item.
+2. Follow the completion protocol (mark subtasks and parent tasks as completed).
+3. Add newly discovered tasks.
+4. Keep "Relevant Files" accurate and up to date.
+5. Before starting work, check which sub‑task is next.
+6. After implementing a sub‑task, update the file and then pause for user approval.
+
+## Cross-links & Quality Gates
+- **Project workflow**: `AGENTS.md` for repository standards and commands
+- **PRs**: Use GitHub as in `AGENTS.md` (MCP tools recommended for PR metadata)
+- **Quality gates**:
+  - All tests pass: `make test` (and `-race`)
+  - Coverage ≥ 90% (CI-style aggregation command in `AGENTS.md`)
+  - Linters pass: `make lint`
+- **Security**: See `docs/security.md`


### PR DESCRIPTION
## Summary
Add three Cursor rule documents aligned with this Go repository's workflows and docs.

## Additions Only
- `.cursor/rules/prd-specification.mdc` — PRD generation rule tailored to Go repo (saves PRDs to `docs/tasks/`, references `AGENTS.md`, `README.md`, Go test/lint/coverage)
- `.cursor/rules/task-breakdown.mdc` — Task list generation rule for Go repo (outputs to `docs/tasks/`, Go testing commands, repo docs in Relevant Files)
- `.cursor/rules/task-progress.mdc` — Task execution/progress rule for Go repo (targeted `go test`, `make test`, coverage ≥ 90%, `make lint`)

## Notes
- No existing files modified; only new rule files were added.
- Content aligns with `AGENTS.md` and `README.md` guidance (tests, coverage, linting, PR discipline).