### PR TITLE
[docs] Phase 6 cache polish: purge CLI, metrics counters, Vary, ops purge

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -401,6 +401,12 @@ llm-proxy manage cache purge \
   --management-token your-token
 ```
 
+**Responses:**
+- Exact purge: `{ "deleted": true|false }`
+- Prefix purge: `{ "deleted": <number_of_entries_deleted> }`
+
+Errors are returned with HTTP status and message. Use `--json` for machine-readable output.
+
 ---
 
 ### `llm-proxy dispatcher`

--- a/docs/instrumentation.md
+++ b/docs/instrumentation.md
@@ -275,6 +275,19 @@ When caching is enabled (`HTTP_CACHE_ENABLED=true`), the proxy adds observabilit
   - `stored`: Response was stored in cache after fetch
   - `conditional-hit`: Conditional request (e.g., `If-None-Match`) resulted in 304
 
+### Cache Metrics
+
+The proxy keeps lightweight, provider-agnostic counters to assess cache effectiveness:
+
+- `cache_hits_total`: Number of requests served from cache (including conditional hits)
+- `cache_misses_total`: Number of requests that missed the cache
+- `cache_bypass_total`: Number of requests where caching was bypassed (e.g., `no-store`)
+- `cache_store_total`: Number of responses stored in cache after upstream fetch
+
+Notes:
+- Counters are in-memory and surfaced via the existing metrics endpoint when enabled.
+- No external metrics provider is required; Prometheus export is optional and not a core dependency.
+
 ### Event Bus Behavior with Caching
 
 The caching system integrates with the instrumentation middleware to optimize performance:


### PR DESCRIPTION
## Summary
Polish documentation for Phase 6 HTTP caching items completed via recent merges, including cache purge management and per-response Vary handling.

## Changes
- docs/cli-reference.md: Add cache purge command response formats and examples
- docs/instrumentation.md: Document cache metrics counters and clarify headers
- docs/architecture.md: Update cache key strategy for per-response Vary; add operations purge section and metrics mention

## Context
- Implements documentation follow-up for [#100](https://github.com/sofatutor/llm-proxy/issues/100) and complements [PR #107](https://github.com/sofatutor/llm-proxy/pull/107).

## Validation
- Build/lint of docs not required; verified content formatting locally.

## Next Steps
- Close #100 once merged
- Consider minor README pointers to these sections
