### PR TITLE
fix: switch to gpt-5.1-codex-mini for better instruction following

### DIFF
--- a/scripts/generate-changelog-entry.sh
+++ b/scripts/generate-changelog-entry.sh
@@ -180,7 +180,7 @@ JSON_PAYLOAD=$(jq -n \
   --arg system "$SYSTEM_PROMPT" \
   --arg user "$USER_PROMPT" \
   '{
-    model: "gpt-4o-mini",
+    model: "gpt-5.1-codex-mini",
     messages: [
       {role: "system", content: $system},
       {role: "user", content: $user}


### PR DESCRIPTION
This pull request updates the language model used in the changelog entry generation script to a newer version for improved performance and accuracy.

Model update:

* [`scripts/generate-changelog-entry.sh`](diffhunk://#diff-f94d6ab02b21817beff5f285caac37feb3cb97713a81046c6f27ca843919a257L183-R183): Changed the model from `gpt-4o-mini` to `gpt-5.1-codex-mini` in the JSON payload.