### PR TITLE
[deploy/helm] Fix Helm publish workflow output parsing

### DIFF
--- a/.github/scripts/helm-publish.sh
+++ b/.github/scripts/helm-publish.sh
@@ -20,11 +20,13 @@ YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
 log_info() {
-    echo -e "${GREEN}[INFO]${NC} $*"
+    # IMPORTANT: log to stderr so command outputs (stdout) remain machine-readable.
+    echo -e "${GREEN}[INFO]${NC} $*" >&2
 }
 
 log_warn() {
-    echo -e "${YELLOW}[WARN]${NC} $*"
+    # IMPORTANT: log to stderr so command outputs (stdout) remain machine-readable.
+    echo -e "${YELLOW}[WARN]${NC} $*" >&2
 }
 
 log_error() {


### PR DESCRIPTION
## Summary
Fix the Helm chart publish workflow failure caused by `helm-publish.sh extract-version` writing log output to **stdout**, which breaks GitHub Actions `GITHUB_OUTPUT` parsing.

Context: merged PR #223 introduced `.github/scripts/helm-publish.sh`. The Helm workflow failed with:
- `Error: Unable to process file command 'output' successfully.`
- `Error: Invalid format '0.0.0-test'`
(see failing job: https://github.com/sofatutor/llm-proxy/actions/runs/20554662752/job/59037135804)

## Changes
- Update `.github/scripts/helm-publish.sh` so `log_info` / `log_warn` write to **stderr**.
  - Stdout is now strictly machine-readable (single-line version), which makes `VERSION=$(...)` safe.

## Testing
- Manual sanity check locally: `extract-version` now returns only the version on stdout (`0.0.0-test` / `1.2.3`) while logs go to stderr.

## Notes
This is a minimal fix PR intended to restore green checks for the Helm workflow without changing behavior.